### PR TITLE
Avoid talking about 'statements' in the context of Haskell programs

### DIFF
--- a/hakyll/pages/ex2-4.md
+++ b/hakyll/pages/ex2-4.md
@@ -3,7 +3,7 @@ title: Generalizing chains of failures
 ---
 
 If you solved challenge #9 correctly, your function has no fewer than five
-case statements.  There are five points where the computation can fail and you
+case expressions.  There are five points where the computation can fail and you
 need to check all of them.  It might bring to mind null checks in C.  The
 difference is that in C the checks are optional because null is a valid
 pointer value.  So in Haskell it actually looks worse than in C because
@@ -91,7 +91,7 @@ This function should have the exact same behavior as queryGreek from the
 previous exercise.
 
 Writing queryGreek2 will probably be more difficult than writing chain.  There
-should be no case statements in queryGreek2--only calls to link or chain.
+should be no case expressions in queryGreek2--only calls to link or chain.
 Once you have it working, play around with other syntax possibilities and see
 if you can get it to look nice.  Hint: lambdas are your friend.
 

--- a/pages/ex2-4.html
+++ b/pages/ex2-4.html
@@ -45,7 +45,7 @@
       <section>
         <h1>Generalizing chains of failures</h1>
 
-        <p>If you solved challenge #9 correctly, your function has no fewer than five case statements. There are five points where the computation can fail and you need to check all of them. It might bring to mind null checks in C. The difference is that in C the checks are optional because null is a valid pointer value. So in Haskell it actually looks worse than in C because Haskell forces you to check everything. (There are ways around it, but we don’t want you to use those right now. And those methods are widely considered unsafe anyway.)</p>
+        <p>If you solved challenge #9 correctly, your function has no fewer than five case expressions. There are five points where the computation can fail and you need to check all of them. It might bring to mind null checks in C. The difference is that in C the checks are optional because null is a valid pointer value. So in Haskell it actually looks worse than in C because Haskell forces you to check everything. (There are ways around it, but we don’t want you to use those right now. And those methods are widely considered unsafe anyway.)</p>
 <p>Bottom line…this is obviously not how we want to write our code. There is a huge amount of repetition in our queryGreek function and we need to figure out how to get rid of it. If you’re really ambitious, stop reading now and see if you can figure it out. If you can’t figure it out don’t worry, keep reading.</p>
 <p>For a clue, let’s take another look at some of the type signatures we’re working with (removing some type class constraints for clarity).</p>
 <pre><code>headMay :: [a] -&gt; Maybe a
@@ -71,7 +71,7 @@ maximumMay :: [a] -&gt; Maybe a</code></pre>
 <p>After you do that, implement this function using your link function. (You can also do it with chain, but link tends to facilitate a more convenient style.)</p>
 <pre><code>queryGreek2 :: GreekData -&gt; String -&gt; Maybe Double</code></pre>
 <p>This function should have the exact same behavior as queryGreek from the previous exercise.</p>
-<p>Writing queryGreek2 will probably be more difficult than writing chain. There should be no case statements in queryGreek2–only calls to link or chain. Once you have it working, play around with other syntax possibilities and see if you can get it to look nice. Hint: lambdas are your friend.</p>
+<p>Writing queryGreek2 will probably be more difficult than writing chain. There should be no case expressions in queryGreek2–only calls to link or chain. Once you have it working, play around with other syntax possibilities and see if you can get it to look nice. Hint: lambdas are your friend.</p>
 
       </section>
     </div>


### PR DESCRIPTION
Haskell has no notion of 'statements' but only 'expressions';
consequently, there are no 'case statements' but only 'case
expressions'.

This addresses a related concern raised in issue #7.
