### PR TITLE
Replaced references to 'allPerms2' function with 'allPerms'

### DIFF
--- a/hakyll/pages/ex3-5.md
+++ b/hakyll/pages/ex3-5.md
@@ -23,7 +23,7 @@ generalization we need.
 Now write that function.  There is only one possible way to do it.  If you can
 write a function that compiles, then your answer is correct.
 
-Now use the permStep function to implement allPerms2 and allPerms3 and check
+Now use the permStep function to implement allPerms and allPerms3 and check
 that the new implementations have the same behavior as before. Once you do this
 it should be pretty obvious how you would use permStep to impliment allPerms4
 and beyond. Also notice how permStep compares to allPerms.

--- a/pages/ex3-5.html
+++ b/pages/ex3-5.html
@@ -49,7 +49,7 @@
 <p>Back? If you figured it out, congratulations. If not, here is the hex encoded type signature for a function called permStep that is the generalization we need.</p>
 <pre><code>7065726D53746570203A3A205B61202D3E20625D202D3E205B615D202D3E205B625D</code></pre>
 <p>Now write that function. There is only one possible way to do it. If you can write a function that compiles, then your answer is correct.</p>
-<p>Now use the permStep function to implement allPerms2 and allPerms3 and check that the new implementations have the same behavior as before. Once you do this it should be pretty obvious how you would use permStep to impliment allPerms4 and beyond. Also notice how permStep compares to allPerms.</p>
+<p>Now use the permStep function to implement allPerms and allPerms3 and check that the new implementations have the same behavior as before. Once you do this it should be pretty obvious how you would use permStep to impliment allPerms4 and beyond. Also notice how permStep compares to allPerms.</p>
 
       </section>
     </div>


### PR DESCRIPTION
There is no 'allPerms2' definition throughout this course. Instead, the
two-lists variant is called just 'allPerms'.
