### PR TITLE
Update ex4-4.md

### DIFF
--- a/hakyll/pages/ex4-4.md
+++ b/hakyll/pages/ex4-4.md
@@ -2,22 +2,22 @@
 title: Creating Instances
 ---
 
-Now you have a Monad type class with two functions: bind and return.  If
+Now you have a Monad type class with two functions: `bind` and `return`.  If
 you've heard anything about monads in the past, this might sound familiar.
 But don't go off and look at existing monad code yet.  You have a lot more
 ground to discover yourself.
 
 The next thing you need to do is create instances of your Monad type class for
-the three types we've been working with: Gen, Maybe, and []. You can do this for
-Maybe and [] with no trouble. But Gen won't work because it is a type alias.
-First you need to replace your type alias with a newtype. Don't go back and
+the three types we've been working with: `Gen`, `Maybe`, and `[]`. You can do this for
+`Maybe` and `[]` with no trouble. But `Gen` won't work because it is a type alias.
+First you need to replace your type alias with a `newtype`. Don't go back and
 modify your old code. We'll be referring back to that in the future. Do this
 work in a new file Set4.hs (again using the same header we've been using and
-importing MCPrelude instead of Haskell's prelude). You can import Set2 because
-that has your Maybe data type and associated code which can be reused. But don't
+importing `MCPrelude` instead of Haskell's prelude). You can import Set2 because
+that has your `Maybe` data type and associated code which can be reused. But don't
 import Set1. When you are finished with this challenge you should have a Set4.hs
-file with a Monad type class, a Gen newtype, and two instances.
+file with a Monad type class, a Gen newtype, and three instances.
 
 If you did all the exercises properly this should be pretty straightforward. The
-Monad instance for Gen may be a little bit less obvious because this time you'll
+Monad instance for `Gen` may be a little bit less obvious because this time you'll
 have to do some newtype wrangling.


### PR DESCRIPTION
- Adds code markers to `bind`, `return`, `Gen`, `Maybe`, `[]` and `MCPrelude`.
- Changes two (2) to three (3) instances. See discussion below.

I got hung up on the `two` here. When completing/finishing this challenge one should have three (3) instances (`Gen`, `Maybe`, and `[]`). Even though only though the next paragraph talks about `Gen`.

So I'd propose to either change it to three, as done in this PR. Or change the wording to say

> When you are finished with this paragraph ...

I did not equate paragraphs to challenges. Challenges for me were the whole exercise.
