### PR TITLE
Update ex2-4.md.

### DIFF
--- a/hakyll/pages/ex2-4.md
+++ b/hakyll/pages/ex2-4.md
@@ -2,13 +2,14 @@
 title: Generalizing chains of failures
 ---
 
-If you solved the last challenge correctly, your function has no fewer than four
+If you solved the last challenge correctly, your function has no fewer than three
 case expressions. There are four points where the computation can fail and you
-need to check all of them. It might bring to mind null checks in C. The
-difference is that in C the checks are optional because null is a valid pointer
-value. So in Haskell it actually looks worse than in C because Haskell forces
-you to check everything. (There are ways around it, but we don't want you to use
-those right now. And those methods are widely considered unsafe anyway.)
+need to check all of them, but two of them fail or succeed together. It might
+bring to mind null checks in C. The difference is that in C the checks are
+optional because null is a valid pointer value. So in Haskell it actually looks
+worse than in C because Haskell forces you to check everything. (There are ways
+around it, but we don't want you to use those right now. And those methods are
+widely considered unsafe anyway.)
 
 Bottom line...this is obviously not how we want to write our code.  There is a
 huge amount of repetition in our queryGreek function and we need to figure out how


### PR DESCRIPTION
Only three case expressions are needed because `headMay` and `tailMay`
succeed or fail together.
