### PR TITLE
Respect Haskell syntax in the example

### DIFF
--- a/hakyll/pages/ex3-2.md
+++ b/hakyll/pages/ex3-2.md
@@ -26,4 +26,4 @@ This function should do the same thing as allPairs, but with more concise
 output.  When you write this function, don't implement it using your previous
 allPairs function.  Rewrite it.
 
-    allCards cardRanks cardSuits == [2H,2D,2C,2S,3H,3D,3C,3S,4H,4D,4C,4S,5H,5D,5C,5S]
+    show (allCards cardRanks cardSuits) == "[2H,2D,2C,2S,3H,3D,3C,3S,4H,4D,4C,4S,5H,5D,5C,5S]"


### PR DESCRIPTION
The last example in 3-2 cannot be copied as is in the Haskell repl, since it is not valid code.
