### PR TITLE
Add code quotes

### DIFF
--- a/hakyll/pages/ex3-5.md
+++ b/hakyll/pages/ex3-5.md
@@ -2,26 +2,26 @@
 title: Combinations of more things
 ---
 
-You probably noticed that allCombs3 is getting painful to write.  Worse still,
+You probably noticed that `allCombs3` is getting painful to write.  Worse still,
 it does not help us generate combinations of four or more things.  We need to
 take a different approach if we want this to scale easily.  This is a
 difficult step, so we are not going to make you figure it out yourself.  All
 the same, spend some time thinking about how you might do it.  Here is a hint
-though.  You probably noticed that allCombs has ([a] -> [b]) in its type
-signature and allCombs3 has ([a] -> [b] -> [c]) in its type signature.  When
+though.  You probably noticed that `allCombs` has `([a] -> [b])` in its type
+signature and `allCombs3` has `([a] -> [b] -> [c])` in its type signature.  When
 you are playing with this, do not try to generalize that pattern to `[[a]]`.
-That is not an adequate generalization because it only allows a and has no b
-or c anywhere.  Spend some time thinking about this before you continue.  But
+That is not an adequate generalization because it only allows `a` and has no `b`
+or `c` anywhere.  Spend some time thinking about this before you continue.  But
 don't be discouraged if you can't figure it out.  This one is hard.
 
 Back?  If you figured it out, congratulations.  If not, here is the hex
-encoded type signature for a function called combStep that is the
+encoded type signature for a function called `combStep` that is the
 generalization we need.
 
     636F6D6253746570203A3A205B61202D3E20625D202D3E205B615D202D3E205B625D
 
-Now write that function. Then use the combStep function to implement allCombs
-and allCombs3 and check that the new implementations have the same behavior as
-before. Once you do this it should be pretty obvious how you would use combStep
-to implement allCombs4 and beyond. Also notice how combStep compares to
-allCombs.
+Now write that function. Then use the `combStep` function to implement `allCombs`
+and `allCombs3` and check that the new implementations have the same behavior as
+before. Once you do this it should be pretty obvious how you would use `combStep`
+to implement `allCombs4` and beyond. Also notice how `combStep` compares to
+`allCombs`.

--- a/hakyll/pages/ex4-5.md
+++ b/hakyll/pages/ex4-5.md
@@ -23,7 +23,7 @@ From set 3:
 * allCombs3 (liftM3)
 * combStep (ap)
 
-You only need to write liftM2 once. But instead of using Gen, Maybe, or [] you
-use m in its place with the `Monad m` type class constraint. Try to do this set
+You only need to write `liftM2` once. But instead of using `Gen`, `Maybe`, or `[]` you
+use `m` in its place with the `Monad m` type class constraint. Try to do this set
 without looking at the code you used before. Just copy all the type signatures
-and redo the work, but this time do everything in terms of return and bind.
+and redo the work, but this time do everything in terms of `return` and `bind`.


### PR DESCRIPTION
Some of the problem description were missing code ticks for function names and such.