### PR TITLE
Improved the challenge descriptions

### DIFF
--- a/hakyll/pages/ex1-1.md
+++ b/hakyll/pages/ex1-1.md
@@ -8,7 +8,7 @@ They maintain some state somewhere in memory and use that to figure out what
 "random" number to give you.  Before the function returns, it modifies the
 mutable state so that the next time you call the function you'll get a
 different number.  Haskell is a pure functional programming language and
-because our custom prelude hides Haskell's mechanisms for dealing with side
+because our custom Prelude hides Haskell's mechanisms for dealing with side
 effects, we can't build a random number generator that way.  Our random number
 generator has to have everything it needs passed in and it has to return
 everything it modifies.  Therefore, it has this type signature:

--- a/hakyll/pages/ex1-1.md
+++ b/hakyll/pages/ex1-1.md
@@ -15,12 +15,12 @@ everything it modifies.  Therefore, it has this type signature:
 
     rand :: Seed -> (Integer, Seed)
 
-You can construct seeds with the mkSeed function.
+You can construct seeds with the `mkSeed` function.
 
     mkSeed :: Integer -> Seed
 
 Make a function that gives you the first five random numbers starting with a
-seed of (mkSeed 1).  Call it:
+seed of `(mkSeed 1)`.  Call it:
 
     fiveRands :: [Integer]
 

--- a/hakyll/pages/ex1-2.md
+++ b/hakyll/pages/ex1-2.md
@@ -2,21 +2,21 @@
 title: Random Character Generation
 ---
 
-Now use the rand function to make your own function for generating random
+Now use the `rand` function to make your own function for generating random
 letters of the alphabet.  It should only generate lower case letters a-z.
 
-We supply a function in MCPrelude called toLetter.  Use the toLetter function
+We supply a function in MCPrelude called `toLetter`.  Use the `toLetter` function
 to write this random letter function:
 
     randLetter :: Seed -> (Char, Seed)
 
-Now use this function to write another function randString3 that generates a
+Now use this function to write another function `randString3` that generates a
 random string of three letters using an initial seed of 1.
 
     randString3 :: String
 
 When you use [this site](http://www.xorbin.com/tools/sha256-hash-calculator) to
-calculate the SHA-256 hash of the output of randString3, you get
+calculate the SHA-256 hash of the output of `randString3`, you get
 9d475eb78d3e38085220ed6ebde9d8f7d26540bb1c8f9382479c3acd4c8c94a3.
 
 [Previous Page](ex1-1.html) - [Next Page](ex1-3.html)

--- a/hakyll/pages/ex1-3.md
+++ b/hakyll/pages/ex1-3.md
@@ -4,7 +4,7 @@ title: More Generators
 
 Now write a few more functions to generate different subsets of random
 numbers.  But first, we need to generalize a bit.  If we look at the type
-signatures for rand and randLetter, what are the commonalities?
+signatures for `rand` and `randLetter`, what are the commonalities?
 
     rand :: Seed -> (Integer, Seed)
     randLetter :: Seed -> (Char, Seed)
@@ -20,21 +20,21 @@ two functions to the following:
 This is a relatively obvious type synonym and it is pretty easy to write, but it
 enables a big mental leap. Now that we have this type synonym we've jumped up a
 level of abstraction and higher level patterns will become more apparent. First
-go back and rewrite all your existing type signatures using this Gen type
+go back and rewrite all your existing type signatures using this `Gen` type
 synonym. Now write three new functions:
 
     randEven :: Gen Integer -- the output of rand * 2
     randOdd :: Gen Integer -- the output of rand * 2 + 1
     randTen :: Gen Integer -- the output of rand * 10
 
-Where randEven and randOdd only generate even and odd numbers respectively,
-randTen only generates multiples of 10.  Write randEven in terms of rand,
-write randOdd in terms of randEven, and write randTen however you want.
+Where `randEven` and `randOdd` only generate even and odd numbers respectively,
+`randTen` only generates multiples of 10.  Write `randEven` in terms of `rand`,
+write `randOdd` in terms of `randEven`, and write `randTen` however you want.
 There's a general pattern lurking here.  If you implement all these functions
-the naive way like you did fiveRands, you'll be repeating the same pattern
+the naive way like you did `fiveRands`, you'll be repeating the same pattern
 over and over.  Figure out how to exploit the common pattern and write a
-function called generalA that implements this pattern.  All three of the above
-functions will also use generalA.  There are a number of different ways you
+function called `generalA` that implements this pattern.  All three of the above
+functions will also use `generalA`.  There are a number of different ways you
 could abstract this.  We realize that you may not pick the right abstraction.
 Play around with as many different possibilities as you can think of.
 

--- a/hakyll/pages/ex1-3.md
+++ b/hakyll/pages/ex1-3.md
@@ -27,20 +27,20 @@ synonym. Now write three new functions:
     randOdd :: Gen Integer -- the output of rand * 2 + 1
     randTen :: Gen Integer -- the output of rand * 10
 
-Where randEven and randOdd generate only even and odd numbers respectively and
-randTen generates only multiples of 10.  Write randEven in terms of rand,
+Where randEven and randOdd only generate even and odd numbers respectively,
+randTen only generates multiples of 10.  Write randEven in terms of rand,
 write randOdd in terms of randEven, and write randTen however you want.
 There's a general pattern lurking here.  If you implement all these functions
 the naive way like you did fiveRands, you'll be repeating the same pattern
 over and over.  Figure out how to exploit the common pattern and write a
-function called generalA that implements the pattern.  All three of the above
+function called generalA that implements this pattern.  All three of the above
 functions will also use generalA.  There are a number of different ways you
 could abstract this.  We realize that you may not pick the right abstraction.
 Play around with as many different possibilities as you can think of.
 
 SPEND SOME TIME WITH THIS BEFORE READING THE HINT!
 
-Play with a number of abstractions and try to find the most flexible.  After
+Play with a number of abstractions and try to find the most flexible one.  After
 you've spent some time with it, look at the hint [here](ex1-3hint.html).
 
 Pass all three of these functions a seed of 1.  They'll give you three numbers

--- a/hakyll/pages/ex1-3hint.md
+++ b/hakyll/pages/ex1-3hint.md
@@ -2,11 +2,11 @@
 title: First Generalization Hint
 ---
 
-All three of these functions are conceptually a call to rand followed by
-applying a function to the integer it returns. What you ultimately need is a
+All three of these functions are conceptually a call to `rand` followed by
+applying a function to the Integer it returns. What you ultimately need is a
 function that you can pass a `Gen a` to and will transform the result.
 
-Be careful not to make your function too specific to rand. rand is a specific example of a `Gen Integer` but you want your function to work for other kinds of `Gen a` as well.
+Be careful not to make your function too specific to `rand`. `rand` is a specific example of a `Gen Integer` but you want your function to work for other kinds of `Gen a` as well.
 
 If you are still stuck, you can view the expected type signature by hex decoding the following string: 67656E6572616C41203A3A202861202D3E206229202D3E2047656E2061202D3E2047656E2062
 

--- a/hakyll/pages/ex1-4.md
+++ b/hakyll/pages/ex1-4.md
@@ -2,16 +2,16 @@
 title: Generalizing Random Pairs
 ---
 
-Use the provided rand function and your randLetter function to make a function
-that generates a random pair of a character and an integer.
+Use the provided `rand` function and your `randLetter` function to make a function
+that generates a random pair of a Char and an Integer.
 
     randPair :: Gen (Char, Integer)
 
 Generate the letter first, then generate the number using the seed acquired from 
-generating the letter.  When you give this function (mkSeed 1) it gives you the 
-random pair ('l',282475249).
+generating the letter.  When you give this function `(mkSeed 1)` it gives you the 
+random pair `('l',282475249)`.
 
-Here we're starting to see the Gen type synonym pay off.  Without Gen, the type
+Here we're starting to see the `Gen` type synonym pay off.  Without `Gen`, the type
 would have been:
 
     randPair :: Seed -> ((Char, Integer), Seed)
@@ -23,8 +23,8 @@ Now generalize the above function.
 
     generalPair :: Gen a -> Gen b -> Gen (a,b)
 
-This function makes the Gen type synonym almost essential.  Here's what we would
-have had to write if we didn't have Gen:
+This function makes the `Gen` type synonym almost essential.  Here's what we would
+have had to write if we didn't have `Gen`:
 
     generalPair :: (Seed -> (a, Seed)) -> (Seed -> (b, Seed)) -> (Seed -> ((a,b), Seed))
 
@@ -34,16 +34,16 @@ help you a little when implementing the function.
     generalPair :: (Seed -> (a, Seed)) -> (Seed -> (b, Seed)) -> Seed -> ((a,b), Seed)
 
 Test this generalized function by comparing its output to what you got from
-randPair.
+`randPair`.
 
 ## Generalizing Pairs Even More
 
-This generalPair function can be generalized even more. Instead of always
+This `generalPair` function can be generalized even more. Instead of always
 constructing pairs, you should be able to have a generalization that can
 construct anything. Your result shouldn't be fixed to `Gen (a,b)`. It should
 also be able to be `Gen String`, `Gen Polynomial`, or `Gen BlogPost`. All you
 need to do is pass in a function that does the constructing with two inputs.
-Call this even more generalized function generalB. Once you have it implemented,
+Call this even more generalized function `generalB`. Once you have it implemented,
 write a new `generalPair2` function in terms of `generalB`.
 
 [Previous Page](ex1-3.html) - [Next Page](ex1-5.html)

--- a/hakyll/pages/ex1-4.md
+++ b/hakyll/pages/ex1-4.md
@@ -7,8 +7,9 @@ that generates a random pair of a character and an integer.
 
     randPair :: Gen (Char, Integer)
 
-Generate the letter first, then the number.  When you give this function (mkSeed
-1) it gives you the random pair ('l',282475249).
+Generate the letter first, then generate the number using the seed acquired from 
+generating the letter.  When you give this function (mkSeed 1) it gives you the 
+random pair ('l',282475249).
 
 Here we're starting to see the Gen type synonym pay off.  Without Gen, the type
 would have been:

--- a/hakyll/pages/ex1-5.md
+++ b/hakyll/pages/ex1-5.md
@@ -3,7 +3,7 @@ title: Generalizing Lists of Generators
 ---
 
 By now you have probably realized that generating multiple random numbers this
-way is rather painful.  You have to thread the output seed from one rand call
+way is rather painful.  You have to thread the output seed from one `rand` call
 to the input of the next call.  This is tedious and error prone, so now you
 will create a function to make this a little easier.
 
@@ -12,12 +12,12 @@ will create a function to make this a little easier.
 This function lets you give it a list of generators and it automatically
 handles the state threading for you.
 
-The nice thing about this function is that [Gen a] is really general, so it
+The nice thing about this function is that `[Gen a]` is really general, so it
 composes well with other built-in list functions.  For example:
 
     repRandom (replicate 3 randLetter) (mkSeed 1)
 
 This function should generate the same three letters that you got from
-randString3 in challenge #2.
+`randString3` in challenge #2.
 
 [Previous Page](ex1-4.html) - [Next Page](ex1-6.html)

--- a/hakyll/pages/ex1-6.md
+++ b/hakyll/pages/ex1-6.md
@@ -5,7 +5,7 @@ title: Threading the random number state
 In the previous exercise we wrote something that handled the threading of state
 through a list of generators.  A simpler idea is to have a function that does
 one step of two generators and the necessary state threading.  Now write a
-function called genTwo that does this.  Its first argument will be a
+function called `genTwo` that does this.  Its first argument will be a
 generator.  Its second argument will be a function that takes the result of
 the first generator and returns a second generator.  The type signature looks
 like this:
@@ -14,20 +14,20 @@ like this:
 
 Implement this function.
 
-Now look at the implementation of your repRandom function.  It probably has one
+Now look at the implementation of your `repRandom` function.  It probably has one
 clause handling the empty list case.  That case probably looks something like this:
 
     repRandom [] s = ([], s)
 
-repRandom was expecting a list of generators and it's supposed to return a
+`repRandom` was expecting a list of generators and it's supposed to return a
 generator. In the empty list case it has no incoming generators to work with but
 it still has to return one. Esentially what's happening here is it has to
-construct a Gen out of thin air. It turns out that this is a really common
-pattern. So let's make a function for it. We'll call this function mkGen. It has
+construct a `Gen` out of thin air. It turns out that this is a really common
+pattern. So let's make a function for it. We'll call this function `mkGen`. It has
 to return a `Gen a`. But it has to get the a from somewhere, so that will have
 to be the argument.
 
-Implement mkGen. Try to figure out the type signature yourself, but if you need
+Implement `mkGen`. Try to figure out the type signature yourself, but if you need
 help here it is hex-encoded: 6D6B47656E203A3A2061202D3E2047656E2061.
 
 You can decode it with [this online hex decoder](http://www.convertstring.com/EncodeDecode/HexDecode).

--- a/hakyll/pages/ex2-1.md
+++ b/hakyll/pages/ex2-1.md
@@ -12,7 +12,7 @@ these exercises, so you should try to get the maximum possible benefit.
 **IMPORTANT**
 
 First of all, you need to define the Maybe type. It should be able to represent
-any value a, as well as the case where no a value exists. This type needs to
+any value a, as well as the case where no value a exists. This type needs to
 represent failing values of any type, so it needs a type variable similar to
 what we saw in the Gen type synonym. But this can't be a type synonym because it
 has two constructors. Write this type yourself and get it to compile. Once

--- a/hakyll/pages/ex2-1.md
+++ b/hakyll/pages/ex2-1.md
@@ -2,19 +2,19 @@
 title: The Maybe Type
 ---
 
-You may have noticed that MCPrelude doesn't have the Maybe type or anything
+You may have noticed that MCPrelude doesn't have the `Maybe` type or anything
 from Data.Maybe.  That's because you're going to build it all yourself.
 
 **IMPORTANT**
-Again, it is imperative that you DO NOT CHEAT.  Don't look at any of the Maybe
+Again, it is imperative that you DO NOT CHEAT.  Don't look at any of the `Maybe`
 stuff from Prelude or Data.Maybe.  Don't do it.  Nobody is forcing you to do
 these exercises, so you should try to get the maximum possible benefit.
 **IMPORTANT**
 
-First of all, you need to define the Maybe type. It should be able to represent
-any value a, as well as the case where no value a exists. This type needs to
+First of all, you need to define the `Maybe` type. It should be able to represent
+any value `a`, as well as the case where no value `a` exists. This type needs to
 represent failing values of any type, so it needs a type variable similar to
-what we saw in the Gen type synonym. But this can't be a type synonym because it
+what we saw in the `Gen` type synonym. But this can't be a type synonym because it
 has two constructors. Write this type yourself and get it to compile. Once
 you've gotten it compiling, check your answer by hex decoding the following:
 
@@ -23,7 +23,7 @@ you've gotten it compiling, check your answer by hex decoding the following:
 You should use this definition and names going forward.  We just wanted you to
 work on it yourself first.
 
-Then for convenience write a Show instance for this new type.
+Then for convenience write a `Show` instance for this new type.
 
     instance Show a => Show (Maybe a) where
 

--- a/hakyll/pages/ex2-2.md
+++ b/hakyll/pages/ex2-2.md
@@ -2,7 +2,7 @@
 title: Build a library of things that can fail
 ---
 
-Now that you have a Maybe type, you need to use it.  So now use it to build
+Now that you have a `Maybe` type, you need to use it.  So now use it to build
 safe versions of several common functions specified by the Prelude.
 
     headMay :: [a] -> Maybe a
@@ -12,15 +12,15 @@ safe versions of several common functions specified by the Prelude.
     maximumMay :: Ord a => [a] -> Maybe a
     minimumMay :: Ord a => [a] -> Maybe a
 
-The functions headMay and tailMay are "safe" versions of the well known head and
-tail functions. The former returns the first element of a list or `Nothing` if the
+The functions `headMay` and `tailMay` are "safe" versions of the well known `head` and
+`tail` functions. The former returns the first element of a list or `Nothing` if the
 list is empty. The latter returns a list containing all but the first element of
-a list, or `Nothing` if the list is empty. The lookupMay function is kind of like
-the lookup for a map. Find the first tuple in the list where the first element
+a list, or `Nothing` if the list is empty. The `lookupMay` function is kind of like
+the `lookup` for a map. Find the first tuple in the list where the first element
 is the equal to the passed in value and return the second element. If there is
-no matching 'a', then return `Nothing`. The divMay function should return `Nothing`
-if you're dividing by zero and the result of the division otherwise. maximumMay
-and minimumMay calculate the maximum and minimum respectively of all the numbers
+no matching `a`, then return `Nothing`. The `divMay` function should return `Nothing`
+if you're dividing by `0` and the result of the division otherwise. `maximumMay`
+and `minimumMay` calculate the maximum and minimum respectively of all the numbers
 in the list, but if the list is empty they return `Nothing`.
 
 [Previous Page](ex2-1.html) - [Next Page](ex2-3.html)

--- a/hakyll/pages/ex2-2.md
+++ b/hakyll/pages/ex2-2.md
@@ -3,7 +3,7 @@ title: Build a library of things that can fail
 ---
 
 Now that you have a Maybe type, you need to use it.  So now use it to build
-safe versions of several common functions specified by the prelude.
+safe versions of several common functions specified by the Prelude.
 
     headMay :: [a] -> Maybe a
     tailMay :: [a] -> Maybe [a]
@@ -13,14 +13,14 @@ safe versions of several common functions specified by the prelude.
     minimumMay :: Ord a => [a] -> Maybe a
 
 The functions headMay and tailMay are "safe" versions of the well known head and
-tail functions. The former returns the first element of a list or Nothing if the
+tail functions. The former returns the first element of a list or `Nothing` if the
 list is empty. The latter returns a list containing all but the first element of
-a list, or Nothing if the list is empty. The lookupMay function is kind of like
+a list, or `Nothing` if the list is empty. The lookupMay function is kind of like
 the lookup for a map. Find the first tuple in the list where the first element
 is the equal to the passed in value and return the second element. If there is
-no matching 'a', then return Nothing. The divMay function should return Nothing
+no matching 'a', then return `Nothing`. The divMay function should return `Nothing`
 if you're dividing by zero and the result of the division otherwise. maximumMay
 and minimumMay calculate the maximum and minimum respectively of all the numbers
-in the list, but if the list is empty they return Nothing.
+in the list, but if the list is empty they return `Nothing`.
 
 [Previous Page](ex2-1.html) - [Next Page](ex2-3.html)

--- a/hakyll/pages/ex2-3.md
+++ b/hakyll/pages/ex2-3.md
@@ -15,16 +15,16 @@ the following type signature:
     queryGreek :: GreekData -> String -> Maybe Double
 
 Your implementation of this function should use the functions you wrote in the
-previous exercise to do the following: first query the GreekData that is passed
+previous exercise to do the following: first query the `GreekData` that is passed
 in, look up the string passed in the second argument, and retrieve the
 corresponding list of Integers. Call this list xs. Next calculate the maximum of
 the tail of xs. (Don't use any pattern matching here. Use case expressions and
-the maximumMay and tailMay functions you wrote in the last exercise.) Take the
-maximum and divide it by the head of the list (using your headMay and divMay
+the `maximumMay` and `tailMay` functions you wrote in the last exercise.) Take the
+maximum and divide it by the head of the list (using your `headMay` and `divMay`
 functions). If any of these operations along the way return `Nothing`, then your
 function should return `Nothing`. But if everything succeeds, then return the
-final quotient. One hint... you'll need to use the fromIntegral function to
-convert your two Integers to Doubles for the final call to divMay.
+final quotient. One hint... you'll need to use the `fromIntegral` function to
+convert your two Integers to Doubles for the final call to `divMay`.
 
 You will probably find this function pretty annoying to implement. Stick with us
 though... there is a point. The more you feel the pain now, the more the

--- a/hakyll/pages/ex2-3.md
+++ b/hakyll/pages/ex2-3.md
@@ -9,25 +9,25 @@ In MCPrelude we have defined the following type synonym for you.
 We also provide two data structures `greekDataA, greekDataB :: GreekData` that
 have some sample data.
 
-Write a function to query the above data structure.  Your function should have
+Write a function to query the above data structures.  Your function should have
 the following type signature:
 
     queryGreek :: GreekData -> String -> Maybe Double
 
 Your implementation of this function should use the functions you wrote in the
-previous exercise to do the following. First query the GreekData that is passed
+previous exercise to do the following: first query the GreekData that is passed
 in, look up the string passed in the second argument, and retrieve the
 corresponding list of Integers. Call this list xs. Next calculate the maximum of
 the tail of xs. (Don't use any pattern matching here. Use case expressions and
 the maximumMay and tailMay functions you wrote in the last exercise.) Take the
 maximum and divide it by the head of the list (using your headMay and divMay
-functions). If any of these operations along the way return Nothing, then your
-function should return Nothing. But if everything succeeds, then return the
-final quotient. One hint...you'll need to use the fromIntegral function to
-convert your two integers to Doubles for the final call to divMay.
+functions). If any of these operations along the way return `Nothing`, then your
+function should return `Nothing`. But if everything succeeds, then return the
+final quotient. One hint... you'll need to use the fromIntegral function to
+convert your two Integers to Doubles for the final call to divMay.
 
 You will probably find this function pretty annoying to implement. Stick with us
-though...there is a point. The more you feel the pain now, the more the
+though... there is a point. The more you feel the pain now, the more the
 solutions will stick in your head later.
 
 Your function should generate the following results:
@@ -45,7 +45,7 @@ Your function should generate the following results:
     queryGreek greekDataB "omega" == Just 24.0
 
 If your function threw any kind of exception on any of those inputs, then your
-implementation is wrong.  Make sure your function always returns a Nothing or
-a Just in every case.
+implementation is wrong.  Make sure your function always returns a `Nothing` or
+a `Just` in every case.
 
 [Previous Page](ex2-2.html) - [Next Page](ex2-4.html)

--- a/hakyll/pages/ex2-4.md
+++ b/hakyll/pages/ex2-4.md
@@ -12,7 +12,7 @@ around it, but we don't want you to use those right now. And those methods are
 widely considered unsafe anyway.)
 
 Bottom line...this is obviously not how we want to write our code.  There is a
-huge amount of repetition in our queryGreek function and we need to figure out how
+huge amount of repetition in our `queryGreek` function and we need to figure out how
 to get rid of it.  If you're really ambitious, stop reading now and see if you
 can figure it out.  If you can't figure it out don't worry, keep reading.
 
@@ -24,15 +24,15 @@ working with (removing some type class constraints for clarity).
     maximumMay :: [a] -> Maybe a
 
 All of these functions look very similar. What is the pattern that they all fit
-into? Well, they all return a Maybe something. And their parameter is always
-something else that is not a Maybe. So how would we generalize this pattern? The
+into? Well, they all return a `Maybe something`. And their parameter is always
+something else that is not a `Maybe`. So how would we generalize this pattern? The
 standard trick to generalizing things is to stick type variables in place of all
 the things that can change. The pattern here looks like this:
 
     :: a -> Maybe b
 
 Now let's see how the other functions fit into this pattern.  First let's look
-at lookupMay.
+at `lookupMay`.
 
     lookupMay :: a -> [(a,b)] -> Maybe b
 
@@ -43,8 +43,8 @@ We could flip the argument order around and supply a fixed list of pairs.
 Bingo, this is exactly the same pattern, so maybe we're on to something.  If
 all of these functions fit into this pattern, how can we remove the
 redundancy?  Well, the problem is that the thing we are always passing to
-these functions is a Maybe.  But the functions need something that is not a
-Maybe.  It sounds like we need a linking function that does this for us.  But
+these functions is a `Maybe`.  But the functions need something that is not a
+`Maybe`.  It sounds like we need a linking function that does this for us.  But
 what will this function look like?  Well, the first thing that it needs is a
 function that fits the above pattern.  So let's start out with a partial type
 signature.
@@ -53,20 +53,20 @@ signature.
 
 Ok, now our chain function has the function that it needs to pass something to.
 But what does it need next?  Well, there are two ways to think about this.
-One way is to think of chain as a function that takes one function and
-transforms it into another function.  Our problem in queryGreek was that we always
+One way is to think of `chain` as a function that takes one function and
+transforms it into another function.  Our problem in `queryGreek` was that we always
 had a `Maybe a` instead of an `a`.  So maybe that suggests what the rest of
 this function should be...
 
     chain :: (a -> Maybe b) -> (Maybe a -> Maybe b)
 
 The other way of thinking about it is what kind of data we had to work with.
-At every step of the way in queryGreek we had a `Maybe a`.  So maybe the next
-argument to chain should be that.
+At every step of the way in `queryGreek` we had a `Maybe a`.  So maybe the next
+argument to `chain` should be that.
 
     chain :: (a -> Maybe b) -> Maybe a -> ...
 
-When we think of it this way, we can view chain as a function that strips off
+When we think of it this way, we can view `chain` as a function that strips off
 the `Maybe` from the `a` and passes it to the function.  If it does that, then
 what will the return type be?  Well, it will be whatever the first function
 returned...in this case a `Maybe b`.
@@ -74,24 +74,24 @@ returned...in this case a `Maybe b`.
     chain :: (a -> Maybe b) -> Maybe a -> Maybe b
 
 If you know the associativity of -> you'll know that this is exactly the same
-as the first type signature we had for chain (minus a set of parenthesis).
+as the first type signature we had for `chain` (minus a set of parenthesis).
 
 With that long winded explanation, we get to your task for this challenge.
-Implement the function chain.  Then implement one more function that is the
-flipped version of chain:
+Implement the function `chain`.  Then implement one more function that is the
+flipped version of `chain`:
 
     link :: Maybe a -> (a -> Maybe b) -> Maybe b
 
-After you do that, implement this function using your link function.  (You can
-also do it with chain, but link tends to facilitate a more convenient style.)
+After you do that, implement this function using your `link` function.  (You can
+also do it with `chain`, but `link` tends to facilitate a more convenient style.)
 
     queryGreek2 :: GreekData -> String -> Maybe Double
 
-This function should have the exact same behavior as queryGreek from the
+This function should have the exact same behavior as `queryGreek` from the
 previous exercise.
 
-Writing queryGreek2 will probably be more difficult than writing chain.  There
-should be no case expressions in queryGreek2--only calls to link or chain.
+Writing `queryGreek2` will probably be more difficult than writing `chain`.  There
+should be no case expressions in `queryGreek2`--only calls to `link` or `chain`.
 Once you have it working, play around with other syntax possibilities and see
 if you can get it to look nice.  Hint: lambdas are your friend.
 

--- a/hakyll/pages/ex2-5.md
+++ b/hakyll/pages/ex2-5.md
@@ -2,7 +2,7 @@
 title: Chaining variations
 ---
 
-Our division function returned a Maybe because there is a case when it can't
+Our division function returned a `Maybe` because there is a case when it can't
 give a meaningful answer.  But what if we were using a different operator that
 doesn't fail?
 
@@ -12,7 +12,7 @@ doesn't fail?
                , ("carol", 85000)
                ]
 
-Write a function addSalaries that adds two salaries by person name.
+Write a function `addSalaries` that adds two salaries by person name.
 
     addSalaries :: [(String, Integer)] -> String -> String -> Maybe Integer
 
@@ -21,31 +21,31 @@ people and it returns the sum of their salaries.  But if you give it a name
 that is not in the list, then there is no way to add the salaries so it should
 return `Nothing`.
 
-Now generalize this pattern in the same way we generalized chain/link in
+Now generalize this pattern in the same way we generalized `chain`/`link` in
 the previous exercise.
 
-Call this function yLink...because it is kind of like a y-shaped chain/link.
+Call this function `yLink`...because it is kind of like a y-shaped `chain`/`link`.
 Coming up with the right type signature is often the tricky part.  Take a look
-at how we came up with the chain type signature in the last exercise and see
-if you can came up with yLink's type signature.  Make a serious effort here.
+at how we came up with the `chain` type signature in the last exercise and see
+if you can came up with `yLink`'s type signature.  Make a serious effort here.
 
 If you were not able to come up with a good generalized type signature, here
 is the hex encoded version of what we are looking for.
 
     794C696E6B203A3A202861202D3E2062202D3E206329202D3E204D617962652061202D3E204D617962652062202D3E204D617962652063
 
-Once you have the type signature, implement yLink using link. *Do not use cases or pattern matching*.  Once
-you have that working, implement addSalaries again as addSalaries2 using yLink
+Once you have the type signature, implement `yLink` using `link`. *Do not use cases or pattern matching*.  Once
+you have that working, implement `addSalaries` again as `addSalaries2` using `yLink`
 this time.
 
-Notice that in both addSalaries and yLink you have to construct a Maybe out of
-thin air kind of like we did in Set 1 with mkGen. Write a similar function for
-Maybes with this type signature.
+Notice that in both `addSalaries` and `yLink` you have to construct a `Maybe` out of
+thin air kind of like we did in Set 1 with `mkGen`. Write a similar function for
+`Maybe`s with this type signature.
 
     mkMaybe :: a -> Maybe a
 
-Now use this function in your addSalaries and yLink functions. You'll probably
-find this easier for Maybe than it was for Gen. It may not seem worthwhile, but
+Now use this function in your `addSalaries` and `yLink` functions. You'll probably
+find this easier for `Maybe` than it was for `Gen`. It may not seem worthwhile, but
 this is all about finding common patterns. This pattern has come up twice in two
 different contexts now, so it's probably worth paying attention to.
 

--- a/hakyll/pages/ex2-5.md
+++ b/hakyll/pages/ex2-5.md
@@ -19,7 +19,7 @@ Write a function addSalaries that adds two salaries by person name.
 You give this function a data structure with salary info and the names of two
 people and it returns the sum of their salaries.  But if you give it a name
 that is not in the list, then there is no way to add the salaries so it should
-return Nothing.
+return `Nothing`.
 
 Now generalize this pattern in the same way we generalized chain/link in
 the previous exercise.

--- a/hakyll/pages/ex2-6.md
+++ b/hakyll/pages/ex2-6.md
@@ -2,8 +2,8 @@
 title: Tailprod
 ---
 
-Write a function that takes the product of the tail of a list.  Use your
-tailMay function and the product function defined in the prelude.  This
+Write a function that calculates the product of the tail of a list.  Use your
+tailMay function and the product function defined in the Prelude.  This
 function should return `Nothing` when passed an empty list,  `Just 1` when
 passed a list of one element (which is what the Prelude's product function
 does), and return the product of the tail for larger lists.

--- a/hakyll/pages/ex2-6.md
+++ b/hakyll/pages/ex2-6.md
@@ -3,9 +3,9 @@ title: Tailprod
 ---
 
 Write a function that calculates the product of the tail of a list.  Use your
-tailMay function and the product function defined in the Prelude.  This
+`tailMay` function and the `product` function defined in the Prelude.  This
 function should return `Nothing` when passed an empty list,  `Just 1` when
-passed a list of one element (which is what the Prelude's product function
+passed a list of one element (which is what the Prelude's `product` function
 does), and return the product of the tail for larger lists.
 
     tailProd :: Num a => [a] -> Maybe a
@@ -15,23 +15,23 @@ Now write a similar but slightly different function:
     tailSum :: Num a => [a] -> Maybe a
 
 These two functions have a lot in common.  See if you can abstract out the
-commonality.  To do this, write another function called transMaybe that is the
+commonality.  To do this, write another function called `transMaybe` that is the
 generalized version of both of these.  Spend some time working on this before
 you look at the next hint:
 
     7472616E734D61796265203A3A202861202D3E206229202D3E204D617962652061202D3E204D617962652062
 
 Write a function with that type signature and then go back and implement
-tailProd and tailSum in terms of that function.
+`tailProd` and `tailSum` in terms of that function.
 
-Now that you have that finished, use transMaybe again to write two more
-functions tailMax and tailMin. These functions will have different type
-signatures than tailProd and tailSum. See if you can figure out what they should
+Now that you have that finished, use `transMaybe` again to write two more
+functions `tailMax` and `tailMin`. These functions will have different type
+signatures than `tailProd` and `tailSum`. See if you can figure out what they should
 be. If you can't figure it out, here's one.
 
     7461696C4D6178203A3A204F72642061203D3E205B615D202D3E204D6179626520284D61796265206129
 
-That type signature is different from the ones above for tailProd and tailSum
+That type signature is different from the ones above for `tailProd` and `tailSum`
 and less convenient to use. To collapse the two levels you'll need another
 helper function. See if you can figure out what the type signature of this
 function should be and how to implement it. Call this function `combine`. Here

--- a/hakyll/pages/ex3-1.md
+++ b/hakyll/pages/ex3-1.md
@@ -16,7 +16,7 @@ input lists.  This means it should NOT have this behavior:
 
     allPairs [1,2,3] [4,5,6] == [(1,4),(2,5),(3,6)]
 
-That's the zip function and it's not what we are looking for here.  Instead,
+That's the `zip` function and it's not what we are looking for here.  Instead,
 your function should generate this:
 
     allPairs [1,2] [3,4] == [(1,3),(1,4),(2,3),(2,4)]

--- a/hakyll/pages/ex3-2.md
+++ b/hakyll/pages/ex3-2.md
@@ -2,29 +2,29 @@
 title: Poker hands
 ---
 
-We can use the allPairs function to do things like generate poker hands.  In
+We can use the `allPairs` function to do things like generate poker hands.  In
 MCPrelude we have defined two lists called `cardRanks` and `cardSuits`.  Try
-calling your allPairs function on these:
+calling your `allPairs` function on these:
 
     allPairs cardRanks cardSuits == [(2,"H"),(2,"D"),(2,"C"),(2,"S"),(3,"H"),(3,"D"),(3,"C"),(3,"S"),(4,"H"),(4,"D"),(4,"C"),(4,"S"),(5,"H"),(5,"D"),(5,"C"),(5,"S")]
 
 But this isn't a very nice representation.  We want a more concise
 representation of the card to show our user.  If you were writing a real
 poker-related program, instead of using a tuple you would probably create a
-data type Card.  Do that now and then write a Show instance for it that
-returns the more concise representation "2H", "2D", etc.
+data type `Card`.  Do that now and then write a `Show` instance for it that
+returns the more concise representation `"2H"`, `"2D"`, etc.
 
     show (Card 2 "h") == "2h"
 
-Now create a new function allCards that does the same thing as your allPairs
-function but uses your new Card data type instead.  It should have the
+Now create a new function `allCards` that does the same thing as your `allPairs`
+function but uses your new `Card` data type instead.  It should have the
 following type signature:
 
     allCards :: [Int] -> [String] -> [Card]
 
-This function should do the same thing as allPairs, but with more concise
+This function should do the same thing as `allPairs`, but with more concise
 output.  When you write this function, don't implement it using your previous
-allPairs function.  Rewrite it.
+`allPairs` function.  Rewrite it.
 
     show (allCards cardRanks cardSuits) == "[2H,2D,2C,2S,3H,3D,3C,3S,4H,4D,4C,4S,5H,5D,5C,5S]"
 

--- a/hakyll/pages/ex3-3.md
+++ b/hakyll/pages/ex3-3.md
@@ -2,13 +2,13 @@
 title: Generalizing pairs and cards
 ---
 
-As we have done before, look at your allPairs and allCards functions and find
+As we have done before, look at your `allPairs` and `allCards` functions and find
 the differences.  Then implement a more general function that can be used to
-implement both allPairs and allCards.  Call this new function allCombs.
+implement both `allPairs` and `allCards`.  Call this new function `allCombs`.
 
     allCombs :: (a -> b -> c) -> [a] -> [b] -> [c]
 
-Then go back and reimplement allPairs and allCards in terms of allCombs.
+Then go back and reimplement `allPairs` and `allCards` in terms of `allCombs`.
 Verify that they do the same thing as the original functions.
 
 [Previous Page](ex3-2.html) - [Next Page](ex3-4.html)

--- a/hakyll/pages/ex3-4.md
+++ b/hakyll/pages/ex3-4.md
@@ -2,8 +2,8 @@
 title: Combinations of three things
 ---
 
-Our allCombs function is more general but it still only lets us generate
-combinations of two things. Now implement an allCombs3 function that generates
+Our `allCombs` function is more general but it still only lets us generate
+combinations of two things. Now implement an `allCombs3` function that generates
 combinations of 3 things. Don't try to do anything fancy yet. Just use the most
 straightforward approach you can think of.
 

--- a/hakyll/pages/ex4-1.md
+++ b/hakyll/pages/ex4-1.md
@@ -22,12 +22,12 @@ this correspondence for yourself.
     67656E54776F207E3D206C696E6B2C2067656E6572616C42207E3D20794C696E6B
 
 Now that you have the correspondences, for each pair write a more general type
-signature that works for both the Gen version and the Maybe version.  Think
+signature that works for both the `Gen` version and the `Maybe` version.  Think
 back to things we've done before.  If two signatures are exactly the same
 except for one difference, replace that difference with a type variable.  It
 doesn't matter what letter you use for the type variable as long as it is
 different from all the other type variables that occur in the signature.  But
-just to make your life easier we'll give you a hint: use the letter 'm'.
+just to make your life easier we'll give you a hint: use the letter `m`.
 Here's the hex-encoded answer:
 
     67656E54776F2C206C696E6B0A20203A3A206D2061202D3E202861202D3E206D206229202D3E206D20620A0A67656E6572616C422C20794C696E6B0A20203A3A202861202D3E2062202D3E206329202D3E206D2061202D3E206D2062202D3E206D2063

--- a/hakyll/pages/ex4-2.md
+++ b/hakyll/pages/ex4-2.md
@@ -9,7 +9,7 @@ implementation and if you didn't write it in terms of `genTwo`, do that now and
 call it `generalB2`. Doing this should get rid of the state threading between
 generators.
 
-Re-implement `repRando`m in terms of `generalA`, `genTwo`, and
+Re-implement `repRandom` in terms of `generalA`, `genTwo`, and
 `mkGen`. Note that by using `generalA`, `genTwo` and `mkGen` you
 should not need to have a `seed` variable in your code for `repRandom` anywhere.
 

--- a/hakyll/pages/ex4-2.md
+++ b/hakyll/pages/ex4-2.md
@@ -2,15 +2,15 @@
 title: A Missed Generalization
 ---
 
-We just found an equivalence between generalB and yLink. In Set 2 we implemented
-yLink in terms of link without using any cases. But in Set 1 you might not have
-implemented generalB in terms of genTwo. Go back and look at your generalB
-implementation and if you didn't write it in terms of genTwo, do that now and
-call it generalB2. Doing this should get rid of the state threading between
+We just found an equivalence between `generalB` and `yLink`. In Set 2 we implemented
+`yLink` in terms of `link` without using any cases. But in Set 1 you might not have
+implemented `generalB` in terms of `genTwo`. Go back and look at your `generalB`
+implementation and if you didn't write it in terms of `genTwo`, do that now and
+call it `generalB2`. Doing this should get rid of the state threading between
 generators.
 
-Re-implement repRandom in terms of generalA, genTwo, and
-mkGen. Note that by using generalA, genTwo and mkGen you
-should not need to have a `seed` variable in your code for repRandom anywhere.
+Re-implement `repRando`m in terms of `generalA`, `genTwo`, and
+`mkGen`. Note that by using `generalA`, `genTwo` and `mkGen` you
+should not need to have a `seed` variable in your code for `repRandom` anywhere.
 
 [Previous Page](ex4-1.html) - [Next Page](ex4-3.html)

--- a/hakyll/pages/ex4-3.md
+++ b/hakyll/pages/ex4-3.md
@@ -14,9 +14,9 @@ do.
 Clearly the random number example and the failing computation example have
 some similarities, but clearly they also have some differences.  We're trying
 to find the smallest set of fundamental primitives that have to be different.
-We have two candidates for those things: genTwo/link and generalB2/yLink.  We
-just saw that generalB2/yLink can be written in terms of genTwo/link, so let's
-assume that the genTwo/link abstraction is part of the fundamental set of
+We have two candidates for those things: `genTwo`/`link` and `generalB2`/`yLink`.  We
+just saw that `generalB2`/`yLink` can be written in terms of `genTwo`/`link`, so let's
+assume that the `genTwo`/`link` abstraction is part of the fundamental set of
 primitives.
 
 Whatever this pattern is that is common between random number generation and
@@ -25,17 +25,17 @@ easily. Let's call it a monad! You know how companies these days have been
 giving themselves nonsensical names that allow them to completely define their
 brand without competing with their customers' preconceived notions of what
 common words mean? We're doing the same thing here. (Well, mathematicians did it
-for us awhile back.) Now that we have a name we need to create a type class:
+for us a while back.) Now that we have a name we need to create a type class:
 
     class Monad m where
 
-The generalized type signature for genTwo/link that you came up with in
+The generalized type signature for `genTwo`/`link` that you came up with in
 challenge #1 is one of the ones we want to put into our type class, and if
-you used the type variable 'm', you should be able to drop it in.  All we need
+you used the type variable `m`, you should be able to drop it in.  All we need
 is a name.  Let's use the name `bind`.
 
 Now that we have part of our type class your task is to create a single unified
-implementation for generalB2/yLink. Most of it should be the same, but you'll
+implementation for `generalB2`/`yLink`. Most of it should be the same, but you'll
 find that there is one part that is different for the two. Make that part into
 the second function of the type class. Call this function `return`. Figure out
 what the type signature should be. We've seen this pattern before in Set 1 and

--- a/hakyll/pages/ex4-4.md
+++ b/hakyll/pages/ex4-4.md
@@ -2,12 +2,12 @@
 title: Creating Instances
 ---
 
-Now you have a Monad type class with two functions: `bind` and `return`.  If
+Now you have a `Monad` type class with two functions: `bind` and `return`.  If
 you've heard anything about monads in the past, this might sound familiar.
 But don't go off and look at existing monad code yet.  You have a lot more
 ground to discover yourself.
 
-The next thing you need to do is create instances of your Monad type class for
+The next thing you need to do is create instances of your `Monad` type class for
 the three types we've been working with: `Gen`, `Maybe`, and `[]`. You can do this for
 `Maybe` and `[]` with no trouble. But `Gen` won't work because it is a type synonym.
 First you need to replace your type synonym with a `newtype`. Don't go back and
@@ -16,15 +16,15 @@ work in a new file Set4.hs (again using the same header we've been using and
 importing `MCPrelude` instead of Haskell's Prelude). You can import Set2 because
 that has your `Maybe` data type and associated code which can be reused. But don't
 import Set1. When you are finished with this challenge you should have a Set4.hs
-file with a Monad type class, a Gen newtype, and three instances.
+file with a `Monad` type class, a `Gen` newtype, and three instances.
 
-Along with your Gen newtype you also might want to write a helper function to
+Along with your `Gen` newtype you also might want to write a helper function to
 make it easier to get your random values out:
 
     evalGen :: Gen a -> Seed -> a
 
 If you did all the exercises properly this should be pretty straightforward. The
-Monad instance for `Gen` may be a little bit less obvious because this time you'll
+`Monad` instance for `Gen` may be a little bit less obvious because this time you'll
 have to do some newtype wrangling.
 
 If you need to brush up your knowledge of some of these topics, check out [this

--- a/hakyll/pages/ex4-4.md
+++ b/hakyll/pages/ex4-4.md
@@ -13,7 +13,7 @@ the three types we've been working with: `Gen`, `Maybe`, and `[]`. You can do th
 First you need to replace your type synonym with a `newtype`. Don't go back and
 modify your old code. We'll be referring back to that in the future. Do this
 work in a new file Set4.hs (again using the same header we've been using and
-importing `MCPrelude` instead of Haskell's prelude). You can import Set2 because
+importing `MCPrelude` instead of Haskell's Prelude). You can import Set2 because
 that has your `Maybe` data type and associated code which can be reused. But don't
 import Set1. When you are finished with this challenge you should have a Set4.hs
 file with a Monad type class, a Gen newtype, and three instances.

--- a/hakyll/pages/ex4-5.md
+++ b/hakyll/pages/ex4-5.md
@@ -3,25 +3,25 @@ title: Revisiting Other Generic Functions
 ---
 
 Now that we have our monad type class and an understanding of what motivated it,
-go back and rewrite the generic functions from sets 1, 2, and 3 using your monad
+go back and rewrite the generic functions from sets 1, 2, and 3 using your `Monad`
 type class. But since we're rewriting them generically we need to give them new
 names. Here are the functions that you should rewrite and the new names that you
 should use. From set 1:
 
-* repRandom (sequence)
-* generalB (liftM2)
+* `repRandom` (`sequence`)
+* `generalB` (`liftM2`)
 
 From set 2:
 
-* chain (=<<)
-* yLink (liftM2)
-* combine (join)
+* `chain` (`=<<`)
+* `yLink` (`liftM2`)
+* `combine` (`join`)
 
 From set 3:
 
-* allCombs (liftM2)
-* allCombs3 (liftM3)
-* combStep (ap)
+* `allCombs` (`liftM2`)
+* `allCombs3` (`liftM3`)
+* `combStep` (`ap`)
 
 You only need to write `liftM2` once. But instead of using `Gen`, `Maybe`, or `[]` you
 use `m` in its place with the `Monad m` type class constraint. Try to do this set

--- a/hakyll/pages/ex4-6.md
+++ b/hakyll/pages/ex4-6.md
@@ -3,7 +3,7 @@ title: Using the abstraction
 ---
 
 Now your Set4.hs module has fairly decent set of abstract tools all built on
-the Monad interface. Now go back through sets 1, 2, and 3 and redo them all
+the `Monad` interface. Now go back through sets 1, 2, and 3 and redo them all
 using the library of functions you built up in Set4.hs. Since `Gen` is now a
 newtype you will have to make some changes to the functions that use it.  This
 may seem like a waste of time, but it will develop your familiarity with the

--- a/hakyll/pages/ex5-1.md
+++ b/hakyll/pages/ex5-1.md
@@ -22,13 +22,13 @@ involved.
     calcFoo :: m a
     bar :: a -> m b
 
-The key is that whatever m is, it must be the same for all three of these types.
+The key is that whatever `m` is, it must be the same for all three of these types.
 Also, `calcFoo` returns an `m a`, but `bar` takes a plain `a`. The bind function
 is responsible for "unboxing" the `m a` and passing the unboxed value to `bar`.
 
 One thing that trips a lot of people up is what to do when they don't have a
-function that looks like `bar`. The version of bar they want might instead have
-this type `bar :: a -> b` (note that here we're specifically saying that bar's
+function that looks like `bar`. The version of `bar` they want might instead have
+this type `bar :: a -> b` (note that here we're specifically saying that `bar`'s
 type signature does NOT have an `m`). Figure out what to do in this situation.
 
 Note this challenge isn't concrete. We're dealing with more abstract types that
@@ -37,6 +37,6 @@ with. We could have written this challenge in a concrete way, but we think it's
 important to learn how to think in more abstract terms. So for this go back to
 the stuff you have done before and find something that you think can be written
 with the do block that `rule1` has. Or better yet, make up a new function that
-does it using Maybe or Gen.
+does it using `Maybe` or `Gen`.
 
 [Previous Page](set5.html) - [Next Page](ex5-2.html)

--- a/hakyll/pages/ex5-2.md
+++ b/hakyll/pages/ex5-2.md
@@ -17,8 +17,8 @@ operator, which can be written infix style like this:
 
     rule1 = calcFoo >>= (\foo -> bar foo)
 
-In order for the do syntax to work correctly, we need to change our Monad class
-to have a >>= operator. Create a class like this:
+In order for the do syntax to work correctly, we need to change our `Monad` class
+to have a `>>=` operator. Create a class like this:
 
     class Monad m where
         (>>=) :: m a -> (a -> m b) -> m b
@@ -29,8 +29,8 @@ to have a >>= operator. Create a class like this:
 
 (Note: for historical reasons, `Monad` is required to have a `fail` function. We
 will not be concerning ourselves with failure here, so we just leave this as undefined.
-When you implement Monad for your own data types, you should only implement the >>= and
-return functions)
+When you implement `Monad` for your own data types, you should only implement the `>>=` and
+`return` functions)
 
 In the next few sections, we will be rewriting the earlier exercises using do syntax.
 

--- a/hakyll/pages/ex5-3.md
+++ b/hakyll/pages/ex5-3.md
@@ -17,7 +17,7 @@ To check that you created this function correctly, recall that the product of th
 you generate when passing in a seed of `mkSeed 1` is 8681089573064486461641871805074254223660.
 
 Once that has been created correctly, create `randLetter :: Gen Char` and use it to create
-`randString3 :: Gen String`, which creates a string of three random characters. If you have an initial seed of 1, when you use [this site](http://www.xorbin.com/tools/sha256-hash-calculator) to
+`randString3 :: Gen String`, which creates a `String` of three random characters. If you have an initial seed of 1, when you use [this site](http://www.xorbin.com/tools/sha256-hash-calculator) to
 calculate the SHA-256 hash of the output of randString3, you get
 9d475eb78d3e38085220ed6ebde9d8f7d26540bb1c8f9382479c3acd4c8c94a3.
 

--- a/hakyll/pages/ex5-3.md
+++ b/hakyll/pages/ex5-3.md
@@ -2,12 +2,12 @@
 title: Do Notation –  Set 1
 ---
 
-First, create an instance of monad for your `Gen` new type, similar to what you did in Set 4.
+First, create an instance of `Monad` for your `Gen` newtype, similar to what you did in Set 4.
 You will also probably want to create an `evalGen :: Gen a -> Seed -> a` function as well.
 
-With your monad instance, you should be able to use do syntax. Recall that in Set 1 we had
+With your `Monad` instance, you should be able to use do syntax. Recall that in Set 1 we had
 a function called `rand :: Seed -> (Integer, Seed)`. Create a new function
-`makeRandom :: Gen Integer` which wraps the rand function inside your new type.
+`makeRandom :: Gen Integer` which wraps the `rand` function inside your new type.
 
 Next, use do syntax to re-create the following function from Set 1:
 

--- a/hakyll/pages/ex5-4.md
+++ b/hakyll/pages/ex5-4.md
@@ -2,7 +2,7 @@
 title: Do Notation –  Set 2
 ---
 
-As with the previous set, you will want to create a Monad instance for your Maybe data type.
+As with the previous set, you will want to create a `Monad` instance for your `Maybe data` type.
 
 Once that is accomplished, rewrite the following functions using do syntax:
 
@@ -14,7 +14,7 @@ Once that is accomplished, rewrite the following functions using do syntax:
 
 You should import Set2 so that you can use the helper functions you wrote in that set.
 
-You can test queryGreek with the following assertions:
+You can test `queryGreek` with the following assertions:
 
     queryGreek greekDataA "alpha" == Just 2.0
     queryGreek greekDataA "beta" == Nothing

--- a/hakyll/pages/ex5-5.md
+++ b/hakyll/pages/ex5-5.md
@@ -2,7 +2,7 @@
 title: Do Notation –  Set 3
 ---
 
-Again, create a Monad instance for your [] type. Import your Card data constructor from Set 3. Using do syntax, implement the following functions:
+Again, create a `Monad` instance for your `[]` type. Import your `Card` data constructor from Set 3. Using do syntax, implement the following functions:
 
     allPairs :: [a] -> [b] -> [(a,b)]
     allCards :: [Int] -> [String] -> [Card]


### PR DESCRIPTION
The following things have been done:

- Fixed a typo in ex2-6
- Made the usage of "Prelude" vs. "prelude" consistent (now everything is "Prelude")
- Marked up all instances of Haskell literals or function names in the text (for example: rand -> `rand`, 0 -> `0`).
- Changed a few sentences in a minor way which, in my opinion, improves the reading flow.