### PR TITLE
Fix type signature of (==) in Eq (Maybe a)

### DIFF
--- a/pages/ex2-1.html
+++ b/pages/ex2-1.html
@@ -60,7 +60,7 @@
 <pre><code>202073686F77204E6F7468696E67203D20224E6F7468696E6722DA202073686F7720284A757374206129203D20224A7573742022202B2B2073686F772061</code></pre>
 <p>You are also going to need an <code>Eq</code> instance as well.</p>
 <pre><code>instance Eq a =&gt; Eq (Maybe a) where
-  (==) :: a -&gt; a -&gt; Bool</code></pre>
+  (==) :: Maybe a -&gt; Maybe a -&gt; Bool</code></pre>
 <p>We’re not going to give you the answer to this one. In the worst case scenario you should be able to figure it out from the way the <code>Show</code> instance was done.</p>
 <p>On the other hand, if writing these instances was too difficult, it might be good to go study some more introductory Haskell materials before continuing here.</p>
 <p><a href="set2.html">Previous Page</a> - <a href="ex2-2.html">Next Page</a></p>


### PR DESCRIPTION
Error if you copy and paste this code into a haskell file:

```
main.hs:6:11: error:
    * Illegal type signature in instance declaration:
        (==) :: a -> a -> Bool
      (Use InstanceSigs to allow this)
    * In the instance declaration for `Eq (Maybe a)'
  |
6 |   (==) :: a -> a -> Bool
  |           ^^^^^^^^^^^^^^
```