### PR TITLE
Add InstanceSigs

### DIFF
--- a/monad-challenges-code/hakyll/index.md
+++ b/monad-challenges-code/hakyll/index.md
@@ -77,7 +77,8 @@ For all of these problem sets you should use the following language pragmas
 and imports:
 
     {-# LANGUAGE MonadComprehensions #-}
-    {-# LANGUAGE RebindableSyntax  #-}
+    {-# LANGUAGE RebindableSyntax #-}
+    {-# LANGUAGE InstanceSigs #-}
 
     module Set1 where
 


### PR DESCRIPTION
I show the Challenges to monad beginners all the time; they're great!

One fairly consistent sticking point comes in set 2 part 1, where the goal is to write `Show` and `Eq` for `Maybe`, and these are provided:

```
instance Show a => Show (Maybe a) where
  show :: (Maybe a) -> String
  
instance Eq a => Eq (Maybe a) where
  (==) :: Maybe a -> Maybe a -> Bool
```

However, implementing these while leaving the type signature around leads to an instance signature error:

```
    • Illegal type signature in instance declaration:
        show :: (Maybe a) -> String
      (Use InstanceSigs to allow this)
    • In the instance declaration for ‘Show (Maybe a)’
```

Maybe the expectation is that people attempting the challenges should be able to understand and solve this. However, in practice I find myself saying "just add the magic comment `{-# LANGUAGE InstanceSigs #-}` to the top of the file" a lot.

Another way to handle this could be to remove the type signatures from the page. However, I think having more explicit information is helpful there.